### PR TITLE
Modernize HTTP checker and refresh documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,37 @@
 # httpResponse
 
-Por mais simples que seja, a ideia é que nem sempre vamos ter todas as ferramentas prontas disponíveis, é necessário saber criar a base.
+Utilitário de linha de comando que envia uma requisição HTTP simples via *sockets* para inspecionar rapidamente a resposta de um servidor.
+
+## Visão Geral
+
+O projeto surgiu como um exemplo minimalista de como podemos construir nossas próprias ferramentas quando bibliotecas mais completas não estão disponíveis. A nova versão foi atualizada para Python 3, ganhou uma interface de linha de comando e oferece feedback mais amigável em caso de falhas de conexão.
+
+## Instalação
+
+Não há dependências externas. Basta clonar este repositório e executar o script diretamente com Python 3.11 ou superior.
+
+```bash
+git clone https://github.com/<seu-usuario>/httpResponse.git
+cd httpResponse
+python3 httpcheck.py --help
+```
+
+## Uso
+
+```bash
+python3 httpcheck.py exemplo.com --path / --header "User-Agent: httpcheck/1.0"
+```
+
+Parâmetros principais:
+
+- `host`: endereço do servidor que receberá a requisição;
+- `--port`: porta TCP (padrão: 80);
+- `--path`: caminho do recurso (padrão: `/`);
+- `--method`: método HTTP (padrão: `GET`);
+- `--header`: cabeçalhos adicionais (pode ser repetido);
+- `--timeout`: tempo máximo de espera em segundos;
+- `--version`: exibe a versão atual da ferramenta.
+
+## Licença
+
+Distribuído sob a licença MIT. Consulte o arquivo [LICENSE](LICENSE) para mais detalhes.

--- a/httpcheck.py
+++ b/httpcheck.py
@@ -1,20 +1,130 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+"""Lightweight HTTP checker utility.
+
+This module exposes a ``main`` function that can be used as a script to
+perform a minimal HTTP request using sockets.  The previous version of this
+file was written for Python 2 and relied on ``raw_input``/``input`` while also
+hard-coding the request payload.  The new implementation embraces Python 3,
+offers a small command line interface and provides better error handling so the
+tool behaves predictably when the target host is unreachable.
+"""
+
+from __future__ import annotations
+
+import argparse
 import socket
+from dataclasses import dataclass
+from typing import Optional
 
-target_host = raw_input("Host: ")
-target_port = input("Port: ")
+__all__ = ["HttpRequest", "perform_request", "main", "__version__"]
+__version__ = "1.0.0"
 
-# create a socket object
-client = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 
-# connect the client
-client.connect((target_host,target_port))
+@dataclass
+class HttpRequest:
+    """Representation of a minimal HTTP request.
 
-# send some data
-client.send(b"GET / HTTP/1.1\r\nHost: google.com\r\n\r\n")
+    Attributes
+    ----------
+    host:
+        Hostname or IP address that will receive the request.
+    port:
+        TCP port where the HTTP service listens.
+    path:
+        Resource path that will be requested.  Defaults to ``"/"``.
+    method:
+        HTTP method to be used when talking to the server.  Defaults to
+        ``"GET"``.
+    headers:
+        Additional headers to be appended to the request.
+    """
 
-# receive some data
-response = client.recv(4096)
+    host: str
+    port: int
+    path: str = "/"
+    method: str = "GET"
+    headers: Optional[list[str]] = None
 
-print(response.decode())
-client.close()
+    def to_bytes(self) -> bytes:
+        """Serialize the request into a raw HTTP payload."""
+
+        request_line = f"{self.method} {self.path} HTTP/1.1\r\n"
+        base_headers = [f"Host: {self.host}", "Connection: close"]
+        serialized_headers = "\r\n".join(base_headers + (self.headers or []))
+        payload = f"{request_line}{serialized_headers}\r\n\r\n"
+        return payload.encode("ascii", errors="ignore")
+
+
+def perform_request(request: HttpRequest, timeout: float = 5.0) -> str:
+    """Send the request and return the raw HTTP response."""
+
+    with socket.create_connection((request.host, request.port), timeout) as sock:
+        sock.sendall(request.to_bytes())
+        chunks: list[bytes] = []
+        while True:
+            chunk = sock.recv(4096)
+            if not chunk:
+                break
+            chunks.append(chunk)
+    return b"".join(chunks).decode("utf-8", errors="replace")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Minimal HTTP response checker")
+    parser.add_argument("host", help="Target host or IP address")
+    parser.add_argument(
+        "-p", "--port", default=80, type=int, help="Port where the server listens"
+    )
+    parser.add_argument(
+        "--path", default="/", help="Resource path to request (default: '/')"
+    )
+    parser.add_argument(
+        "-X", "--method", default="GET", help="HTTP method to use (default: GET)"
+    )
+    parser.add_argument(
+        "-H",
+        "--header",
+        action="append",
+        default=[],
+        metavar="HEADER",
+        help="Additional header lines to send (can be repeated)",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=5.0,
+        help="Socket timeout in seconds (default: 5)",
+    )
+    parser.add_argument(
+        "-V",
+        "--version",
+        action="version",
+        version=f"httpcheck {__version__}",
+        help="Show program's version number and exit",
+    )
+    return parser
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    request = HttpRequest(
+        host=args.host,
+        port=args.port,
+        path=args.path,
+        method=args.method.upper(),
+        headers=args.header or None,
+    )
+
+    try:
+        response = perform_request(request, timeout=args.timeout)
+    except (socket.timeout, ConnectionError, OSError) as exc:  # pragma: no cover - best effort
+        parser.error(f"Failed to connect to {request.host}:{request.port} -> {exc}")
+    else:
+        print(response)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- rewrite the legacy Python 2 socket client into a Python 3 friendly CLI with version reporting
- add structured request handling, optional headers, and improved error messages
- expand the README with installation, usage, and licensing details

## Testing
- python3 httpcheck.py --help

------
https://chatgpt.com/codex/tasks/task_e_68e426154f38832abf66e12687f37437